### PR TITLE
Hide default translation message when default locale is active

### DIFF
--- a/lib/acts_as_simple_translatable/class_methods.rb
+++ b/lib/acts_as_simple_translatable/class_methods.rb
@@ -15,7 +15,7 @@ module ActsAsSimpleTranslatable
       fields.each do |field|
         define_method "#{field}" do |default_message = 'NO TRANSLATION'|
           content = (I18n.locale == I18n.default_locale) ? super() : locale_translations[field]
-          content.present? ? content : default_message
+          content.present? || (I18n.locale == I18n.default_locale) ? content : default_message
         end
 
         define_method "#{field}_original" do


### PR DESCRIPTION
It's ugly when in all places/form inputs is default_message.
